### PR TITLE
Add mail function to wp-config.php on image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY [".htaccess", "/usr/src/wordpress"]
 
 # Setup SMTP running config.sh
 COPY ["apache2-config.sh", "/usr/local/bin/"]
-CMD ["apache2-config.sh"]
+RUN [ "/usr/local/bin/apache2-config.sh" ]

--- a/apache2-config.sh
+++ b/apache2-config.sh
@@ -19,6 +19,3 @@ function mail_smtp( \$phpmailer ) {
   \$phpmailer->FromName = getenv('WORDPRESS_SMTP_FROM_NAME');
 }
 EOF
-
-# Run apache2
-exec "apache2-foreground"


### PR DESCRIPTION
The way you implemented patching the PHP function, you will append the function each time you restart the container. This is usually not a problem if you use the container forever or you recreate it each time. Setups using docker swarm or even docker compose, with restart option, will have issues.